### PR TITLE
Fix exception raising

### DIFF
--- a/lib/siebel_donations/base.rb
+++ b/lib/siebel_donations/base.rb
@@ -23,9 +23,9 @@ module SiebelDonations
           when 200
             Oj.load(response.unpack("C*").pack("U*").force_encoding("UTF-8").encode!)
           when 400
-            raise RestClient::BadRequest, response.to_s
+            raise RestClient::BadRequest, response
           when 500
-            raise RestClient::InternalServerError, response.to_s
+            raise RestClient::InternalServerError, response
           else
             puts response.inspect
             puts request.inspect


### PR DESCRIPTION
A new `RestClient::Exception` expects the response object to be passed in as the first param: https://github.com/rest-client/rest-client/blob/v2.0.2/lib/restclient/exceptions.rb#L114

This will fix: https://rollbar.com/Cru/mpdx_api/items/2855/ and https://rollbar.com/Cru/mpdx_api/items/1952/