### PR TITLE
allow for configuration of retry count

### DIFF
--- a/lib/siebel_donations.rb
+++ b/lib/siebel_donations.rb
@@ -7,7 +7,7 @@ end
 
 module SiebelDonations
   class << self
-    attr_accessor :base_url, :oauth_token, :default_timeout
+    attr_accessor :base_url, :oauth_token, :default_timeout, :default_retry_count
 
     def configure
       yield self
@@ -19,6 +19,10 @@ module SiebelDonations
 
     def default_timeout
       @default_timeout || 6000
+    end
+
+    def default_retry_count
+      @default_retry_count || 20
     end
   end
 end


### PR DESCRIPTION
MPDX has a place where these requests are blocking the request thread. If we are going to make that request, we don't want to retry 20 times and risk having a total time being (1 + 20) * 6 second timeout.