### PR TITLE
allow setting timeouts for request

### DIFF
--- a/lib/siebel_donations/base.rb
+++ b/lib/siebel_donations/base.rb
@@ -14,7 +14,8 @@ module SiebelDonations
     def self.get(path, params)
       raise 'You need to configure SiebelDonations with your oauth_token.' unless SiebelDonations.oauth_token
 
-      params[:response_timeout] ||= SiebelDonations.default_timeout
+      request_timeout = params[:timeout] || SiebelDonations.default_timeout
+      params[:response_timeout] ||= request_timeout
       retry_count = params.delete(:retry_count) || SiebelDonations.default_retry_count
 
       url = SiebelDonations.base_url + path
@@ -23,7 +24,7 @@ module SiebelDonations
       retryable_errors = [RestClient::InternalServerError, Timeout::Error, Errno::ECONNRESET]
 
       Retryable.retryable on: retryable_errors, times: retry_count, sleep: 20 do
-        request_params = { method: :get, url: url, headers: headers, timeout: SiebelDonations.default_timeout }
+        request_params = { method: :get, url: url, headers: headers, timeout: request_timeout }
         RestClient::Request.execute(request_params) do |response, request, result, &block|
           case response.code
           when 200

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe SiebelDonations::Base do
+  context '.get' do
+    context 'with timeout param set' do
+      it 'passes param to RestClient' do
+        expect(RestClient::Request).to receive(:execute)
+          .with(hash_including(url: SiebelDonations.base_url, timeout: 123))
+          .and_return(nil)
+
+        described_class.get('', timeout: 123)
+      end
+    end
+
+    context 'without timeout param set' do
+      it 'passes default to RestClient' do
+        expect(RestClient::Request).to receive(:execute)
+          .with(hash_including(timeout: 6000))
+          .and_return(nil)
+
+        described_class.get('', {})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added for https://github.com/CruGlobal/mpdx_api/pull/2175 (not technically required, but it would be nice to set shorter timeouts for request threads)

RestClient timeout docs: https://github.com/rest-client/rest-client/blob/2.1.x/lib/restclient/request.rb#L41-L43